### PR TITLE
fix:[고침] 유저가 가입한 달에 다음달 목표가 무조건 변경되었다고 리턴되는 오류

### DIFF
--- a/footprint/src/main/java/com/umc/footprint/src/users/UserDao.java
+++ b/footprint/src/main/java/com/umc/footprint/src/users/UserDao.java
@@ -1147,7 +1147,10 @@ public class UserDao {
     // 다음달 목표 변경 여부 확인
     public boolean checkGoalModified(int userIdx){
 
-        String getUpdateAtQuery = "SELECT IF(MONTH(updateAt) = MONTH(NOW()), true, false) FROM GoalNext WHERE userIdx = ?";
+        String getUpdateAtQuery = "SELECT IF(YEAR(createAt) = YEAR(NOW()) and MONTH(createAt) = MONTH(NOW()), " +
+                                            "IF(createAt = updateAt, false, true), " +
+                                            "IF(YEAR(updateAt) = YEAR(NOW()) and MONTH(updateAt) = MONTH(NOW()), true, false) ) " +
+                                    "FROM GoalNext WHERE userIdx = ?";
         boolean updateBool = this.jdbcTemplate.queryForObject(getUpdateAtQuery,Boolean.class,userIdx);
 
         return updateBool;


### PR DESCRIPTION
## 유저가 가입한 달에 다음달 목표가 무조건 변경되었다고 리턴되는 오류
-> 쿼리문 수정으로 해결
-> 연도가 변경될시에도 발생하는 문제 추가 해결(ex. 2021년 02월에 마지막 변경 & 현재 2022년 02월까지 변경 없을시에 변경되었다고 리턴 )