### PR TITLE
hotfix:[수정] 안드-서버 요일별 인덱스 차이 문제

### DIFF
--- a/footprint/src/main/java/com/umc/footprint/src/users/UserService.java
+++ b/footprint/src/main/java/com/umc/footprint/src/users/UserService.java
@@ -115,6 +115,20 @@ public class UserService {
         try {
             int resultInfo = userDao.modifyUserInfo(userIdx, patchUserInfoReq);
             log.debug("resultInfo: {}", resultInfo);
+
+            // 요일별 인덱스 차이 해결을 위한 임시 코드
+            List<Integer> dayIdxList = new ArrayList<>();
+            for (Integer dayIdx: patchUserInfoReq.getDayIdx()){
+                if(dayIdx == 7)
+                    dayIdxList.add(1);
+                else
+                    dayIdxList.add(dayIdx+1);
+            }
+            Collections.sort(dayIdxList);
+            patchUserInfoReq.setDayIdx(dayIdxList);
+            log.debug("dayIdxList : {}",dayIdxList);
+            //
+
             int result = userDao.postGoal(userIdx, patchUserInfoReq);
             log.debug("result : {}", result);
             int resultNext = userDao.postGoalNext(userIdx, patchUserInfoReq);


### PR DESCRIPTION
## 안드-서버 요일별 인덱스 차이 문제해결
기존 : 일 : 1 / 월 : 2 / 화 : 3 / 수 : 4 / 목 : 5 / 금 : 6 / 토 : 7
변경 : 월 : 1 / 화 : 2 / 수 : 3 / 목 : 4 / 금 : 5 / 토 : 6 / 일 : 7