### PR TITLE
improve:[변경] request의 암호화 여부를 filter에서 구분하여 복호화/암호화

### DIFF
--- a/footprint/src/main/java/com/umc/footprint/filter/DecodingFilter.java
+++ b/footprint/src/main/java/com/umc/footprint/filter/DecodingFilter.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 public class DecodingFilter implements Filter {
     private static final Logger logger = LoggerFactory.getLogger(DecodingFilter.class);
     private final EncryptProperties encryptProperties;
+    private static Boolean isEncrypted;
 
     public DecodingFilter(EncryptProperties encryptProperties){
         this.encryptProperties = encryptProperties;
@@ -38,7 +39,7 @@ public class DecodingFilter implements Filter {
 
             RequestBodyDecryptWrapper requestWrapper = new RequestBodyDecryptWrapper(req, encryptProperties);
 
-            chain.doFilter(requestWrapper, response);
+            chain.doFilter(requestWrapper, response);   // ** doFilter **
 
             logger.info("Return URI: {}", req.getRequestURL());
         } catch (Exception exception){

--- a/footprint/src/main/java/com/umc/footprint/filter/FilterConfiguration.java
+++ b/footprint/src/main/java/com/umc/footprint/filter/FilterConfiguration.java
@@ -26,7 +26,6 @@ public class FilterConfiguration implements WebMvcConfigurer {
 
         System.out.println("URL =" + registrationBean.getUrlPatterns());
 
-
         return registrationBean;
     }
 
@@ -34,11 +33,18 @@ public class FilterConfiguration implements WebMvcConfigurer {
     public FilterRegistrationBean<EncodingFilter> encodingFilterRegistrationBean(){
         FilterRegistrationBean<EncodingFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new EncodingFilter(encryptProperties));
-        registrationBean.addUrlPatterns("/*");
+        registrationBean.addUrlPatterns("/users/*");
+        registrationBean.addUrlPatterns("/footprints/*");
+        registrationBean.addUrlPatterns("/walks/*");
+        registrationBean.addUrlPatterns("/weather");
+
 
         System.out.println("URL =" + registrationBean.getUrlPatterns());
 
         return registrationBean;
     }
+
+
+
 
 }

--- a/footprint/src/main/java/com/umc/footprint/src/check/CheckController.java
+++ b/footprint/src/main/java/com/umc/footprint/src/check/CheckController.java
@@ -1,0 +1,45 @@
+package com.umc.footprint.src.check;
+
+import com.umc.footprint.config.BaseException;
+import com.umc.footprint.config.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/check")
+public class CheckController {
+
+    private final CheckService checkService;
+
+    public CheckController(CheckService checkService){
+        this.checkService = checkService;
+    }
+
+
+    @ResponseBody
+    @PostMapping("/encrypt") // (POST) 127.0.0.1:3000/walks/check/encrypt
+    public BaseResponse<String> checkEncryptWalk(@RequestBody String encryptString){
+        try {
+
+            String encryptedString = checkService.checkEncryptWalk(encryptString);
+
+            return new BaseResponse<>(encryptedString);
+
+        } catch (BaseException exception) {
+            return new BaseResponse<>((exception.getStatus()));
+        }
+    }
+
+
+    @ResponseBody
+    @PostMapping("/decrypt") // (POST) 127.0.0.1:3000/walks/check/decrypt
+    public BaseResponse<String> checkDecryptWalk(@RequestBody String decryptString) throws BaseException {
+
+        String decryptedString = checkService.checkDecryptWalk(decryptString);
+
+        return new BaseResponse<>(decryptedString);
+    }
+
+
+}

--- a/footprint/src/main/java/com/umc/footprint/src/check/CheckService.java
+++ b/footprint/src/main/java/com/umc/footprint/src/check/CheckService.java
@@ -1,0 +1,45 @@
+package com.umc.footprint.src.check;
+
+import com.umc.footprint.config.BaseException;
+import com.umc.footprint.config.EncryptProperties;
+import com.umc.footprint.utils.AES128;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.umc.footprint.config.BaseResponseStatus.DATABASE_ERROR;
+
+@Slf4j
+@Service
+public class CheckService {
+
+    private final EncryptProperties encryptProperties;
+
+    public CheckService(EncryptProperties encryptProperties){
+        this.encryptProperties = encryptProperties;
+    }
+
+    public String checkEncryptWalk(String encryptString) throws BaseException {
+        try{
+            String encryptResult = new AES128(encryptProperties.getKey()).encrypt(encryptString);
+
+            log.info("encryptResult = {}",encryptResult );
+
+            return encryptResult;
+        } catch(Exception exception) {
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    public String checkDecryptWalk(String decryptString) throws BaseException{
+        try{
+            System.out.println("decryptString = " + decryptString);
+            String decryptResult = new AES128(encryptProperties.getKey()).decrypt(decryptString);
+
+            System.out.println("decryptResult = " + decryptResult);
+
+            return decryptResult;
+        } catch(Exception exception) {
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+}

--- a/footprint/src/main/java/com/umc/footprint/src/walks/WalkController.java
+++ b/footprint/src/main/java/com/umc/footprint/src/walks/WalkController.java
@@ -143,29 +143,4 @@ public class WalkController {
         }
     }
 
-
-    @ResponseBody
-    @PostMapping("/check/encrypt") // (POST) 127.0.0.1:3000/walks/check/encrypt
-    public BaseResponse<String> checkEncryptWalk(@RequestBody String encryptString){
-        try {
-
-            String encryptedString = walkService.checkEncryptWalk(encryptString);
-
-            return new BaseResponse<>(encryptedString);
-
-        } catch (BaseException exception) {
-            return new BaseResponse<>((exception.getStatus()));
-        }
-    }
-
-
-    @ResponseBody
-    @PostMapping("/check/decrypt") // (POST) 127.0.0.1:3000/walks/check/decrypt
-    public BaseResponse<String> checkDecryptWalk(@RequestBody String decryptString) throws BaseException {
-        
-        String decryptedString = walkService.checkDecryptWalk(decryptString);
-
-        return new BaseResponse<>(decryptedString);
-    }
-
 }

--- a/footprint/src/main/java/com/umc/footprint/src/walks/WalkService.java
+++ b/footprint/src/main/java/com/umc/footprint/src/walks/WalkService.java
@@ -267,29 +267,5 @@ public class WalkService {
         }
     }
 
-    public String checkEncryptWalk(String encryptString) throws BaseException{
-        try{
-            String encryptResult = new AES128(encryptProperties.getKey()).encrypt(encryptString);
-
-            log.info("encryptResult = {}",encryptResult );
-
-            return encryptResult;
-        } catch(Exception exception) {
-            throw new BaseException(DATABASE_ERROR);
-        }
-    }
-
-    public String checkDecryptWalk(String decryptString) throws BaseException{
-        try{
-            System.out.println("decryptString = " + decryptString);
-            String decryptResult = new AES128(encryptProperties.getKey()).decrypt(decryptString);
-
-            System.out.println("decryptResult = " + decryptResult);
-            
-            return decryptResult;
-        } catch(Exception exception) {
-            throw new BaseException(DATABASE_ERROR);
-        }
-    }
 
 }


### PR DESCRIPTION
## Main Idea 
- 비암호화 되어있는 request는 {~} 형태의 json 형식으로 와서 request가 '{'로 시작하는지의 여부를 가지고 암호화 여부를 구분함
## 1. Decoding Filter (in RequestBodyDecryptWrapper)
- 비암호화된 Request 일때 복호화 진행 없이 Request Servlet으로 전달 
- 암호화 데이터라면 암호화 여부를 정적 변수에 저장 ( Boolean isEncrypted )
## 2. Encoding Filter
- 해당 데이터가 비암호화된 데이터라면 response 암호화 없이 전달
## 3. 기존 /walk/check/encrypt,decrypt => /check/decrypt 로 URI 변경