### PR TITLE
fix:[수정] scheduler Time

### DIFF
--- a/footprint/src/main/java/com/umc/footprint/src/schedule/UserSchedule.java
+++ b/footprint/src/main/java/com/umc/footprint/src/schedule/UserSchedule.java
@@ -33,19 +33,19 @@ public class UserSchedule {
         userDao.updateGoalDay();
     }
 
-    @Transactional
-    @Scheduled(cron = "0 45 20 29 * ?")
-    public void changeMonthGoalTest(){
-
-        userDao.updateGoal();
-        userDao.updateGoalDay();
-
-        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
-
-        log.info("=== Schedule now : {} ===",now);
-        log.debug("=== Schedule now : {} ===",now);
-        
-    }
+//    @Transactional
+//    @Scheduled(cron = "0 45 20 29 * ?")
+//    public void changeMonthGoalTest(){
+//
+//        userDao.updateGoal();
+//        userDao.updateGoalDay();
+//
+//        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+//
+//        log.info("=== Schedule now : {} ===",now);
+//        log.debug("=== Schedule now : {} ===",now);
+//
+//    }
 
 
 }


### PR DESCRIPTION
## 기존 서버에 올라가면 UTC로 달라지는 서버시간 수정
FootprintApplication안에 @PostConstruct 어노테이션을 이용하여 TimeZone을 Asia/Seoul로 설정
-> 의존성 주입이 이루어진 후 서버시간 초기화를 수행한다.

_여기 코드에는 @PostConstruct 변경 코드 없음(전 커밋에 있음)_ 